### PR TITLE
Add SmartShunt BLE packet support

### DIFF
--- a/custom_components/renogy/ble.py
+++ b/custom_components/renogy/ble.py
@@ -32,7 +32,10 @@ from .const import (
     RENOGY_READ_CHAR_UUID,
     RENOGY_WRITE_CHAR_UUID,
     UNAVAILABLE_RETRY_INTERVAL,
+    RENOGY_SHUNT_MANUF_ID,
+    DeviceType,
 )
+from .parser import parse_shunt_packet
 
 try:
     from renogy_ble import RenogyParser
@@ -583,6 +586,20 @@ class RenogyActiveBluetoothCoordinator(ActiveBluetoothDataUpdateCoordinator):
                     device.name,
                     device.address,
                 )
+
+                if self.device.device_type == DeviceType.SHUNT.value:
+                    manu = service_info.advertisement.manufacturer_data.get(
+                        RENOGY_SHUNT_MANUF_ID
+                    )
+                    if manu:
+                        try:
+                            metrics = parse_shunt_packet(bytes(manu))
+                            self.device.parsed_data = metrics
+                            LOGGER.debug("Parsed SmartShunt data: %s", metrics)
+                            return True
+                        except ValueError:
+                            LOGGER.warning("Invalid Shunt packet: %s", manu)
+                    return False
 
                 # Use bleak-retry-connector for more robust connection
                 try:

--- a/custom_components/renogy/const.py
+++ b/custom_components/renogy/const.py
@@ -14,6 +14,7 @@ MAX_SCAN_INTERVAL = 600  # seconds
 
 # Renogy BT-1 and BT-2 module identifiers - devices advertise with these prefixes
 RENOGY_BT_PREFIX = "BT-TH-"
+RENOGY_SHUNT_MANUF_ID = 0x4C00
 
 # Configuration parameters
 CONF_SCAN_INTERVAL = "scan_interval"
@@ -28,6 +29,7 @@ class DeviceType(Enum):
     CONTROLLER = "controller"
     BATTERY = "battery"
     INVERTER = "inverter"
+    SHUNT = "shunt"
 
 
 # List of supported device types
@@ -53,6 +55,15 @@ MAX_NOTIFICATION_WAIT_TIME = 2.0
 
 # Default device ID for Renogy devices
 DEFAULT_DEVICE_ID = 0xFF
+
+# SmartShunt sensor keys
+KEY_SHUNT_BUS_VOLTAGE = "bus_voltage"
+KEY_SHUNT_SHUNT_DROP = "shunt_drop"
+KEY_SHUNT_CURRENT = "current"
+KEY_SHUNT_CONSUMED_AH = "consumed_ah"
+KEY_SHUNT_STATE_OF_CHARGE = "state_of_charge"
+KEY_SHUNT_TEMPERATURE = "temperature"
+KEY_SHUNT_EXTRA_FLAGS = "extra_flags"
 
 # Modbus commands for requesting data
 COMMANDS = {

--- a/custom_components/renogy/parser.py
+++ b/custom_components/renogy/parser.py
@@ -1,0 +1,41 @@
+"""Parsing helpers for Renogy BLE integrations."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def parse_shunt_packet(data: bytes) -> Dict[str, float | int | None]:
+    """Parse a Renogy SmartShunt manufacturer specific packet."""
+    if len(data) < 12:
+        raise ValueError("packet too short")
+
+    offset = 2  # skip manufacturer id
+    if len(data) < offset + 10:
+        raise ValueError("packet too short")
+
+    bus_mv = int.from_bytes(data[offset : offset + 2], "big")
+    offset += 2
+    shunt_uv = int.from_bytes(data[offset : offset + 2], "big")
+    offset += 2
+    current_ma = int.from_bytes(data[offset : offset + 2], "big", signed=True)
+    offset += 2
+    consumed = int.from_bytes(data[offset : offset + 2], "big")
+    offset += 2
+    soc = data[offset]
+    offset += 1
+    temperature_raw = data[offset]
+    offset += 1
+    extra = data[offset] if len(data) > offset else None
+
+    metrics = {
+        "bus_voltage": bus_mv / 1000,
+        "shunt_drop": shunt_uv / 1000,
+        "current": current_ma / 1000,
+        "consumed_ah": consumed / 100,
+        "state_of_charge": max(0, min(soc, 100)),
+        "temperature": temperature_raw - 40,
+        "extra_flags": extra,
+    }
+
+    return metrics

--- a/custom_components/renogy/sensor.py
+++ b/custom_components/renogy/sensor.py
@@ -36,6 +36,14 @@ from .const import (
     DOMAIN,
     LOGGER,
     RENOGY_BT_PREFIX,
+    DeviceType,
+    KEY_SHUNT_BUS_VOLTAGE,
+    KEY_SHUNT_SHUNT_DROP,
+    KEY_SHUNT_CURRENT,
+    KEY_SHUNT_CONSUMED_AH,
+    KEY_SHUNT_STATE_OF_CHARGE,
+    KEY_SHUNT_TEMPERATURE,
+    KEY_SHUNT_EXTRA_FLAGS,
 )
 
 # Registry of sensor keys
@@ -267,6 +275,63 @@ CONTROLLER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
     ),
 )
 
+SHUNT_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
+    RenogyBLESensorDescription(
+        key=KEY_SHUNT_BUS_VOLTAGE,
+        name="Bus Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_SHUNT_BUS_VOLTAGE),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_SHUNT_SHUNT_DROP,
+        name="Shunt Drop",
+        native_unit_of_measurement="mV",
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_SHUNT_SHUNT_DROP),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_SHUNT_CURRENT,
+        name="Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_SHUNT_CURRENT),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_SHUNT_CONSUMED_AH,
+        name="Consumed Ah",
+        native_unit_of_measurement="Ah",
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_SHUNT_CONSUMED_AH),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_SHUNT_STATE_OF_CHARGE,
+        name="State Of Charge",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_SHUNT_STATE_OF_CHARGE),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_SHUNT_TEMPERATURE,
+        name="Temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_SHUNT_TEMPERATURE),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_SHUNT_EXTRA_FLAGS,
+        name="Extra Flags",
+        device_class=None,
+        value_fn=lambda data: data.get(KEY_SHUNT_EXTRA_FLAGS),
+    ),
+)
+
 # All sensors combined
 ALL_SENSORS = BATTERY_SENSORS + PV_SENSORS + LOAD_SENSORS + CONTROLLER_SENSORS
 
@@ -343,13 +408,17 @@ def create_entities_helper(
     """Create sensor entities with provided coordinator and optional device."""
     entities = []
 
-    # Group sensors by category
-    for category_name, sensor_list in {
-        "Battery": BATTERY_SENSORS,
-        "PV": PV_SENSORS,
-        "Load": LOAD_SENSORS,
-        "Controller": CONTROLLER_SENSORS,
-    }.items():
+    if device_type == DeviceType.SHUNT.value:
+        groups = {"Shunt": SHUNT_SENSORS}
+    else:
+        groups = {
+            "Battery": BATTERY_SENSORS,
+            "PV": PV_SENSORS,
+            "Load": LOAD_SENSORS,
+            "Controller": CONTROLLER_SENSORS,
+        }
+
+    for category_name, sensor_list in groups.items():
         for description in sensor_list:
             sensor = RenogyBLESensor(
                 coordinator, device, description, category_name, device_type

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,51 @@
+import pytest
+
+import importlib.util
+from pathlib import Path
+
+PARSER_PATH = Path(__file__).resolve().parents[1] / "custom_components" / "renogy" / "parser.py"
+CONST_PATH = Path(__file__).resolve().parents[1] / "custom_components" / "renogy" / "const.py"
+
+spec_parser = importlib.util.spec_from_file_location("parser", PARSER_PATH)
+parser = importlib.util.module_from_spec(spec_parser)
+spec_parser.loader.exec_module(parser)
+
+spec_const = importlib.util.spec_from_file_location("const", CONST_PATH)
+const = importlib.util.module_from_spec(spec_const)
+spec_const.loader.exec_module(const)
+
+parse_shunt_packet = parser.parse_shunt_packet
+RENOGY_SHUNT_MANUF_ID = const.RENOGY_SHUNT_MANUF_ID
+
+
+def test_parse_shunt_packet_valid():
+    data = bytes(
+        [
+            (RENOGY_SHUNT_MANUF_ID >> 8) & 0xFF,
+            RENOGY_SHUNT_MANUF_ID & 0xFF,
+            0x2E,
+            0xE0,
+            0x27,
+            0x10,
+            0x03,
+            0xE8,
+            0x00,
+            0xFA,
+            0x50,
+            0x41,
+            0x01,
+        ]
+    )
+    result = parse_shunt_packet(data)
+    assert result["bus_voltage"] == 12.0
+    assert result["shunt_drop"] == 10.0
+    assert result["current"] == 1.0
+    assert result["consumed_ah"] == 2.5
+    assert result["state_of_charge"] == 80
+    assert result["temperature"] == 25
+    assert result["extra_flags"] == 1
+
+
+def test_parse_shunt_packet_invalid_length():
+    with pytest.raises(ValueError):
+        parse_shunt_packet(b"\x00\x01\x02")


### PR DESCRIPTION
## Summary
- parse Renogy SmartShunt manufacturer packets
- support SmartShunt constants and sensor keys
- detect SmartShunt data in BLE reader
- expose SmartShunt sensors
- test parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ae6d87b8832899c3311c012b4ca8