### PR TITLE
Support new SmartShunt BLE packets

### DIFF
--- a/custom_components/renogy/const.py
+++ b/custom_components/renogy/const.py
@@ -53,7 +53,7 @@ RENOGY_WRITE_CHAR_UUID = (
 )
 
 # SmartShunt notification service/characteristic UUID
-RENOGY_SHUNT_PACKET_SERVICE_UUID = "0000c211-0000-1000-8000-00805f9b34fb"
+RENOGY_SHUNT_PACKET_SERVICE_UUID = "0000c411-0000-1000-8000-00805f9b34fb"
 
 # Time in minutes to wait before attempting to reconnect to unavailable devices
 UNAVAILABLE_RETRY_INTERVAL = 10

--- a/tests/test_ble_harness.py
+++ b/tests/test_ble_harness.py
@@ -13,8 +13,9 @@ def test_parse_hex():
     assert data == bytes([0x00, 0xFF])
 
 
-def test_decode_lines_soc_packet():
-    lines = ["00-01-0C-03-02-00-A5"]
+def test_decode_lines_numeric_packet():
+    lines = ["AA-55-44-2E-E0-27-10-03-E8-00-FA-50-41-01"]
     results = ble_harness.decode_lines(lines)
-    assert results[0]["packetType"] == "0x0C03"
-    assert results[0]["state_of_charge"] == 100
+    assert results[0]["packetType"] == "0x44"
+    assert results[0]["bus_voltage"] == 12.0
+    assert results[0]["state_of_charge"] == 80

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -51,9 +51,36 @@ def test_parse_shunt_packet_invalid_length():
         parse_shunt_packet(b"\x00\x01\x02")
 
 
-def test_parse_shunt_ble_packet_0c03():
-    data = bytes([0x00, 0x01, 0x0C, 0x03, 0x02, 0x00, 0xA5])
+def test_parse_shunt_ble_packet_model_id():
+    data = b"\x00\x01\x10RSSHUNT"
     result = parse_shunt_ble_packet(data)
-    assert result["packetType"] == "0x0C03"
-    assert result["socRaw"] == 0x00A5
-    assert result["state_of_charge"] == 100
+    assert result["packetType"] == "0x10"
+    assert result["model_id"] == "RSSHUNT"
+
+
+def test_parse_shunt_ble_packet_numeric():
+    data = bytes([
+        0xAA,
+        0x55,
+        0x44,
+        0x2E,
+        0xE0,
+        0x27,
+        0x10,
+        0x03,
+        0xE8,
+        0x00,
+        0xFA,
+        0x50,
+        0x41,
+        0x01,
+    ])
+    result = parse_shunt_ble_packet(data)
+    assert result["packetType"] == "0x44"
+    assert result["bus_voltage"] == 12.0
+    assert result["shunt_drop"] == 10.0
+    assert result["current"] == 1.0
+    assert result["consumed_ah"] == 2.5
+    assert result["state_of_charge"] == 80
+    assert result["temperature"] == 25
+    assert result["extra_flags"] == 1

--- a/tools/ble_test_harness.py
+++ b/tools/ble_test_harness.py
@@ -51,7 +51,7 @@ def decode_payload(payload: bytes, register: int = 0) -> dict:
             return RenogyParser.parse(payload, "shunt", register)
         except Exception as exc:  # pragma: no cover - runtime aid only
             return {"error": str(exc)}
-    # Fallback handles only SmartShunt SOC packets (0x0C03)
+    # Fallback handles SmartShunt notification packets
     try:
         return parse_shunt_ble_packet(payload)
     except Exception as exc:  # pragma: no cover - runtime aid only


### PR DESCRIPTION
## Summary
- implement decoder for SmartShunt FFF1 notification packets
- update constant for shunt service UUID
- adjust tests and harness for the new packet format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685abf4477348328b0b9529903db5b56