### PR TITLE
Support multi-format SmartShunt BLE messages

### DIFF
--- a/custom_components/renogy/parser.py
+++ b/custom_components/renogy/parser.py
@@ -5,6 +5,15 @@ from __future__ import annotations
 from typing import Dict
 
 
+def _bytes_to_int(bs: bytes, offset: int, length: int, *, signed: bool = False, scale: float = 1.0) -> float | int | None:
+    """Helper to convert a slice of ``bs`` into a scaled integer."""
+    if len(bs) < offset + length:
+        return None
+    raw = int.from_bytes(bs[offset : offset + length], "big", signed=signed)
+    value: float | int = raw * scale
+    return round(value, 2) if isinstance(value, float) else value
+
+
 def parse_shunt_packet(data: bytes) -> Dict[str, float | int | None]:
     """Parse a Renogy SmartShunt manufacturer specific packet."""
     if len(data) < 12:
@@ -47,36 +56,109 @@ def parse_shunt_ble_packet(data: bytes) -> Dict[str, float | int | str]:
     if len(data) < 4:
         raise ValueError("packet too short")
 
+    # Two distinct packet formats are supported. Firmware that prefixes packets
+    # with ``AA55`` uses ``data[2]`` as a packet type (e.g. ``0x44``).  Older
+    # firmware omits the prefix but still places the packet type at index ``2``.
+
     packet_type = data[2]
-    payload = data[3:]
 
-    if packet_type == 0x10:
-        # ASCII model ID string
-        model_id = payload.decode("ascii", errors="ignore").strip()
-        return {"packetType": "0x10", "model_id": model_id}
+    # Known typed packets (0x10 ASCII, 0x44 numeric metrics)
+    if packet_type in (0x10, 0x44):
+        payload = data[3:]
 
-    if packet_type == 0x44:
-        if len(payload) < 11:
-            raise ValueError("payload too short")
+        if packet_type == 0x10:
+            # ASCII model ID string
+            model_id = payload.decode("ascii", errors="ignore").strip()
+            return {"packetType": "0x10", "model_id": model_id}
 
-        bus_v = int.from_bytes(payload[0:2], "big") / 1000.0
-        drop_mv = int.from_bytes(payload[2:4], "big") / 1000.0
-        curr_a = int.from_bytes(payload[4:6], "big", signed=True) / 1000.0
-        consumed_ah = int.from_bytes(payload[6:8], "big") / 100.0
-        soc_raw = payload[8]
-        soc = max(0, min(soc_raw, 100))
-        temp_c = payload[9] - 40
-        flags = payload[10]
+        if packet_type == 0x44:
+            if len(payload) < 11:
+                raise ValueError("payload too short")
 
-        return {
-            "packetType": "0x44",
-            "bus_voltage": bus_v,
-            "shunt_drop": drop_mv,
-            "current": curr_a,
-            "consumed_ah": consumed_ah,
-            "state_of_charge": soc,
-            "temperature": temp_c,
-            "extra_flags": flags,
-        }
+            bus_v = int.from_bytes(payload[0:2], "big") / 1000.0
+            drop_mv = int.from_bytes(payload[2:4], "big") / 1000.0
+            curr_a = int.from_bytes(payload[4:6], "big", signed=True) / 1000.0
+            consumed_ah = int.from_bytes(payload[6:8], "big") / 100.0
+            soc_raw = payload[8]
+            soc = max(0, min(soc_raw, 100))
+            temp_c = payload[9] - 40
+            flags = payload[10]
 
-    raise ValueError(f"Unsupported packet type: 0x{packet_type:02X}")
+            metrics = {
+                "packetType": "0x44",
+                "bus_voltage": bus_v,
+                "shunt_drop": drop_mv,
+                "current": curr_a,
+                "consumed_ah": consumed_ah,
+                "state_of_charge": soc,
+                "temperature": temp_c,
+                "extra_flags": flags,
+            }
+            metrics["power_watts"] = round(bus_v * curr_a, 2)
+            return metrics
+
+        raise ValueError(f"Unsupported packet type: 0x{packet_type:02X}")
+
+    # Group based message format
+    group_id = data[3]
+    payload = data[4:]
+    metrics: Dict[str, float | int | str] = {"packetType": f"0x{group_id:02X}"}
+
+    if group_id == 0x03:
+        raw = int.from_bytes(payload[3:5], "little")
+        metrics["state_of_charge"] = round(raw * 0.1, 1)
+        return metrics
+
+    if group_id == 0x05:
+        raw = int.from_bytes(payload[3:7], "little")
+        metrics["battery_voltage"] = round(raw * 0.001, 3)
+        return metrics
+
+    if group_id == 0x04:
+        raw = int.from_bytes(payload[3:6], "little", signed=True)
+        amps = round(raw * 0.001, 3)
+        metrics["discharge_amps"] = amps
+        if "battery_voltage" in metrics:
+            metrics["power_watts"] = round(metrics["battery_voltage"] * amps, 2)
+        return metrics
+
+    if group_id == 0x02:
+        mins = _bytes_to_int(payload, 3, 4)
+        if mins is not None:
+            metrics["remaining_time_h"] = round(mins / 60, 2)
+        return metrics
+
+    if group_id == 0x0B:
+        metrics["consumed_Ah"] = _bytes_to_int(payload, 3, 4, scale=0.1)
+        return metrics
+
+    if group_id == 0x06:
+        mins = _bytes_to_int(payload, 3, 2)
+        if mins is not None:
+            metrics["discharge_duration_h"] = round(mins / 60, 2)
+        return metrics
+
+    if group_id == 0x0D:
+        metrics["temperature_C"] = _bytes_to_int(payload, 3, 2, signed=True, scale=0.1)
+        return metrics
+
+    if group_id == 0x07:
+        metrics["starter_volts"] = _bytes_to_int(payload, 3, 4, scale=0.001)
+        return metrics
+
+    raise ValueError(f"Unsupported group id: 0x{group_id:02X}")
+
+def parse_shunt_ble_messages(messages: list[bytes]) -> Dict[str, float | int | str]:
+    """Parse multiple SmartShunt BLE packets and merge the metrics."""
+    result: Dict[str, float | int | str] = {}
+    for msg in messages:
+        try:
+            metrics = parse_shunt_ble_packet(msg)
+        except ValueError:
+            continue
+        result.update(metrics)
+    bus_v = result.get("battery_voltage") or result.get("bus_voltage")
+    amps = result.get("discharge_amps") or result.get("current")
+    if bus_v is not None and amps is not None:
+        result["power_watts"] = round(float(bus_v) * float(amps), 2)
+    return result

--- a/tests/test_ble_harness.py
+++ b/tests/test_ble_harness.py
@@ -7,6 +7,11 @@ spec = importlib.util.spec_from_file_location("ble_harness", HARNESS_PATH)
 ble_harness = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(ble_harness)
 
+PARSER_PATH = Path(__file__).resolve().parents[1] / "custom_components" / "renogy" / "parser.py"
+spec_parser = importlib.util.spec_from_file_location("parser", PARSER_PATH)
+parser = importlib.util.module_from_spec(spec_parser)
+spec_parser.loader.exec_module(parser)
+
 
 def test_parse_hex():
     data = ble_harness._parse_hex("(0x) 00-FF")
@@ -19,3 +24,22 @@ def test_decode_lines_numeric_packet():
     assert results[0]["packetType"] == "0x44"
     assert results[0]["bus_voltage"] == 12.0
     assert results[0]["state_of_charge"] == 80
+
+
+def test_decode_lines_group_packet():
+    lines = ["00-01-0C-03-0A-06-00-31-01-9B-EA"]
+    results = ble_harness.decode_lines(lines)
+    assert results[0]["packetType"] == "0x03"
+    assert results[0]["state_of_charge"] == 30.5
+
+
+def test_decode_lines_multi_packet():
+    lines = [
+        "00-01-0C-05-06-06-00-9C-34-00-00-96-37",
+        "00-01-0C-03-0A-06-00-31-01-9B-EA",
+    ]
+    results = ble_harness.decode_lines(lines)
+    merged = parser.parse_shunt_ble_messages([ble_harness._parse_hex(l) for l in lines])
+    assert merged["battery_voltage"] == 13.468
+    assert merged["state_of_charge"] == 30.5
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -84,3 +84,30 @@ def test_parse_shunt_ble_packet_numeric():
     assert result["state_of_charge"] == 80
     assert result["temperature"] == 25
     assert result["extra_flags"] == 1
+
+
+def test_parse_shunt_ble_packet_group_battery_voltage():
+    data = bytes.fromhex(
+        "00-01-0C-05-06-06-00-9C-34-00-00-96-37".replace("-", "")
+    )
+    result = parse_shunt_ble_packet(data)
+    assert result["packetType"] == "0x05"
+    assert result["battery_voltage"] == 13.468
+
+
+def test_parse_shunt_ble_packet_group_soc():
+    data = bytes.fromhex("00-01-0C-03-0A-06-00-31-01-9B-EA".replace("-", ""))
+    result = parse_shunt_ble_packet(data)
+    assert result["packetType"] == "0x03"
+    assert result["state_of_charge"] == 30.5
+
+
+def test_parse_shunt_ble_messages_merge():
+    packets = [
+        bytes.fromhex("00-01-0C-05-06-06-00-9C-34-00-00-96-37".replace("-", "")),
+        bytes.fromhex("00-01-0C-03-0A-06-00-31-01-9B-EA".replace("-", "")),
+    ]
+    result = parser.parse_shunt_ble_messages(packets)
+    assert result["battery_voltage"] == 13.468
+    assert result["state_of_charge"] == 30.5
+


### PR DESCRIPTION
## Summary
- expand `parse_shunt_ble_packet` to compute power and expose all values
- add `parse_shunt_ble_messages` helper for merging multiple packets
- test new helper in parser and BLE harness

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b1ec75b588328b99cf9f82c2fc0e8